### PR TITLE
Issue #48: changed the evergreen search website

### DIFF
--- a/sites/all/modules/features/evergreen_search_box/evergreen_search_box.features.fe_block_boxes.inc
+++ b/sites/all/modules/features/evergreen_search_box/evergreen_search_box.features.fe_block_boxes.inc
@@ -16,7 +16,7 @@ function evergreen_search_box_default_fe_block_boxes() {
   $fe_block_boxes->machine_name = 'catalog_search';
   $fe_block_boxes->body = '<p><em>This search box will open a new window with your search results.</em></p>
 
-<form target="_blank" action="https://evergreen.sltchristian.edu/eg/opac/results" method="get">
+<form target="_blank" action="https://evergreen.stlchristian.edu/eg/opac/results" method="get">
     <input type="search" id="evergreen-search-box" alt="Catalog Search" maxlength="200" size="25" name="query" placeholder="Search for keywords..." />
     <input type="hidden" name="qtype" value="keyword" />
     <input type="hidden" name="locg" value="4" />


### PR DESCRIPTION
Switched the evergreen search from slcconline.edu  to the newer to
sltchristian.edu so that the searches in the catalog would work.
